### PR TITLE
trasnmitter - Fix bug - forgot to awake the scheduler

### DIFF
--- a/src/lkby_transmitter.c
+++ b/src/lkby_transmitter.c
@@ -110,5 +110,6 @@ void *lkby_start_transmitter(void *none __attribute__((unused)))
             lkbyqueue_dequeue(&trasmit_data, &LKBYQUEUE(&g_transmit_queue));
             send_data_to_users(&trasmit_data);
         }
+	(void) sem_post(&LKBYQUEUE_SEM(&g_transmit_queue));
     }
 }


### PR DESCRIPTION
Fix bug: The issue was that the scheduler was in sleep mode and the transmitter did not wake it up, causing both threads to remain asleep while waiting for a sem_post to activate them.